### PR TITLE
Rate-limiting, updating urls, and adding more functions.

### DIFF
--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -29,28 +29,55 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
+
 class riotapi {
 	const API_URL_1_1 = 'http://prod.api.pvp.net/api/lol/{region}/v1.1/';
 	const API_URL_1_2 = 'http://prod.api.pvp.net/api/lol/{region}/v1.2/';
-	const API_URL_2_1 = 'http://prod.api.pvp.net/api/lol/{region}/v2.2/';
-	const API_KEY = 'API_KEY_HERE';
-	const RATE_LIMIT_MINUTES = 500;
-	const RATE_LIMIT_SECONDS = 10;
+	const API_URL_1_3 = 'http://prod.api.pvp.net/api/lol/{region}/v1.3/';
+	const API_URL_1_4 = 'http://prod.api.pvp.net/api/lol/{region}/v1.4/';
+	const API_URL_2_1 = 'http://prod.api.pvp.net/api/lol/{region}/v2.1/';
+	const API_URL_2_2 = 'http://prod.api.pvp.net/api/lol/{region}/v2.2/';
+	const API_URL_2_3 = "http://prod.api.pvp.net/api/lol/{region}/v2.3/";
+	const API_URL_STATIC_1_2 = 'http://prod.api.pvp.net/api/lol/static-data/{region}/v1.2/';
+
+	const API_KEY = 'INSERT_API_KEY_HERE';
+
+	// Rate limit for 10 minutes
+	const LONG_LIMIT_INTERVAL = 600;
+	const RATE_LIMIT_LONG = 500;
+
+	// Rate limit for 10 seconds'
+	const SHORT_LIMIT_INTERVAL = 10;
+	const RATE_LIMIT_SHORT = 10;
+
+	// Cache variables
 	const CACHE_LIFETIME_MINUTES = 60;
 	const CACHE_ENABLED = true;
 	private $REGION;
-	
+
 	public function __construct($region)
 	{
-		$this->REGION = $region;		
+		$this->REGION = $region;
+
+		$this->shortLimitQueue = new SplQueue();
+		$this->longLimitQueue = new SplQueue();
+
+
 	}
 
 	public function getChampion(){
 		$call = 'champion';
 
 		//add API URL to the call
-		$call = self::API_URL_1_1 . $call;
+		$call = self::API_URL_1_2 . $call;
 
+		return $this->request($call);
+	}
+
+	//performs a static call. Not counted in rate limit.
+	public function getStatic($call=null, $id=null) {
+		$call = self::API_URL_STATIC_1_2 . $call . "/" . $id;
+		
 		return $this->request($call);
 	}
 
@@ -58,28 +85,40 @@ class riotapi {
 		$call = 'game/by-summoner/' . $id . '/recent';
 
 		//add API URL to the call
-		$call = self::API_URL_1_2 . $call;
+		$call = self::API_URL_1_3 . $call;
 
 		return $this->request($call);
 	}
 
-	public function getLeague($id){
-		$call = 'league/by-summoner/' . $id;
+	public function getLeague($id, $entry=null){
+		$call = 'league/by-summoner/' . $id . "/" . $entry;
 
 		//add API URL to the call
-		$call = self::API_URL_2_2 . $call;
+		$call = self::API_URL_2_3 . $call;
 
 		return $this->request($call);
+	}
+	public function getChallenger() {
+		$call = 'league/challenger?type=RANKED_SOLO_5x5';
+
+		//add API URL to the call
+		$call = self::API_URL_2_3 . $call;
+		return $this->request($call, true);
 	}
 
 	public function getStats($id,$option='summary'){
 		$call = 'stats/by-summoner/' . $id . '/' . $option;
 
 		//add API URL to the call
-		$call = self::API_URL_1_2 . $call;
+		$call = self::API_URL_1_3 . $call;
 
 		return $this->request($call);
 	}
+	//returns a summoner's id
+	public function getSummonerId($name) {
+			$summoner = $this->getSummonerByName($name);
+			return $summoner[$name]["id"];
+	}		
 
 	public function getSummoner($id,$option=null){
 		$call = 'summoner/' . $id;
@@ -93,14 +132,14 @@ class riotapi {
 			case 'name':
 				$call .= '/name';
 				break;
-			
+
 			default:
 				//do nothing
 				break;
 		}
 
 		//add API URL to the call
-		$call = self::API_URL_1_2 . $call;
+		$call = self::API_URL_1_4 . $call;
 
 		return $this->request($call);
 	}
@@ -113,7 +152,7 @@ class riotapi {
 		$call = 'summoner/by-name/' . rawurlencode($name);
 
 		//add API URL to the call
-		$call = self::API_URL_1_2 . $call;
+		$call = self::API_URL_1_4 . $call;
 
 		return $this->request($call);
 	}
@@ -123,18 +162,63 @@ class riotapi {
 		$call = 'team/by-summoner/' . $id;
 
 		//add API URL to the call
-		$call = self::API_URL_2_1 . $call;
+		$call = self::API_URL_2_2 . $call;
 
 		return $this->request($call);
 	}
 
-	private function request($call){
+	private function updateLimitQueue($queue, $interval, $call_limit){
+		
+		while(!$queue->isEmpty()){
+			
+			/* Three possibilities here.
+			1: There are timestamps outside the window of the interval,
+			which means that the requests associated with them were long
+			enough ago that they can be removed from the queue.
+			2: There have been more calls within the previous interval
+			of time than are allowed by the rate limit, in which case
+			the program blocks to ensure the rate limit isn't broken.
+			3: There are openings in window, more requests are allowed,
+			and the program continues.*/
+
+			$timeSinceOldest = time() - $queue->bottom();
+			// I recently learned that the "bottom" of the
+			// queue is the beginning of the queue. Go figure.
+
+			// Remove timestamps from the queue if they're older than
+			// the length of the interval
+			if($timeSinceOldest > $interval){
+					$queue->dequeue();
+			}
+			
+			// Check to see whether the rate limit would be broken; if so,
+			// block for the appropriate amount of time
+			elseif($queue->count() >= $call_limit){
+				if($timeSinceOldest < $interval){ //order of ops matters
+					echo("sleeping for".($interval - $timeSinceOldest + 1)." seconds\n");
+					sleep($interval - $timeSinceOldest);
+				}
+			}
+			// Otherwise, pass through and let the program continue.
+			else {
+				break;
+			}
+		}
+
+		// Add current timestamp to back of queue; this represents
+		// the current request.
+		$queue->enqueue(time());
+	}
+
+	private function request($call, $otherQueries=false) {
 
 		//probably should put rate limiting stuff here
-
+		// Check rate-limiting queues
+		$this->updateLimitQueue($this->longLimitQueue, self::LONG_LIMIT_INTERVAL, self::RATE_LIMIT_LONG);
+		$this->updateLimitQueue($this->shortLimitQueue, self::SHORT_LIMIT_INTERVAL, self::RATE_LIMIT_SHORT);
 
 		//format the full URL
-		$url = $this->format_url($call);
+		$url = $this->format_url($call, $otherQueries);
 
 		//caching
 		if(self::CACHE_ENABLED){
@@ -146,7 +230,8 @@ class riotapi {
 
 		        // if data was cached recently, return cached data
 		        if ($cacheTime > strtotime('-'. self::CACHE_LIFETIME_MINUTES . ' minutes')) {
-		            return fread($fh,filesize($cacheFile));
+		            $data = fread($fh,filesize($cacheFile));
+		            return $data;
 		        }
 
 		        // else delete cache file
@@ -160,26 +245,26 @@ class riotapi {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		$result = curl_exec($ch);
 		curl_close($ch);
-		
+
 		if(self::CACHE_ENABLED){
 			//create cache file
-		    $fh = fopen($cacheFile, 'w');
-		    fwrite($fh, time() . "\n");
-		    fwrite($fh, $result);
-		    fclose($fh);
-		}
-
-		return $result;	
-
+			file_put_contents($cacheFile . ".txt", time() . "\n" . $result);
+		}	
+		return $result;
 	}
 
 	//creates a full URL you can query on the API
-	private function format_url($call){
+	private function format_url($call, $otherQueries=false){
+		//because sometimes your url looks like .../something/foo?query=blahblah&api_key=dfsdfaefe
+		if ($otherQueries) {
+			return str_replace('{region}', $this->REGION, $call) . '&api_key=' . self::API_KEY;
+		}
 		return str_replace('{region}', $this->REGION, $call) . '?api_key=' . self::API_KEY;
 	}
+
+	public function debug($message) {
+		echo "<pre>";
+		print_r($message);
+		echo "</pre>";
+	}
 }
-
-
-
-
-?>


### PR DESCRIPTION
*Implemented rate limiting using SplQueue. NOW REQUIRES PHP >= 5.3.
*Fixed call ur's to be more recent.
*Added getLeague() call.
*added getChallenger() call.
*added getSummonerId() call.
*Format_url now allows for additional arguments to be queried in the
call. Example -- if you call /league/challenger?type=RANKED_SOLO_5x5,
you don't get an error saying "missing API key".
*replaced file writing code with simple file_put_contents() call.
*added a debug() function for recursively printing a json_decode'd
array.
