### PR TITLE
Split caching into it's own class

### DIFF
--- a/CacheInterface.php
+++ b/CacheInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+interface CacheInterface {
+
+	/**
+	 * @param string $key Check if the cache contains data for the specified key
+	 * @return bool
+	 */
+	public function has($key);
+
+	/**
+	 * @param string $key Gets data for specified key
+	 * @return string|null Returns null if the cache has expired or non-existing data
+	 */
+	public function get($key);
+
+	/**
+	 * @param string $key
+	 * @param $data
+	 * @param int $ttl Time for the data to live inside the cache
+	 * @return mixed
+	 */
+	public function put($key, $data, $ttl = 0);
+
+}

--- a/CacheInterface.php
+++ b/CacheInterface.php
@@ -3,21 +3,21 @@
 interface CacheInterface {
 
 	/**
-	 * @param string $key Check if the cache contains data for the specified key
+	 * @param string $key Checks whether or not the cache contains unexpired data for the specified key
 	 * @return bool
 	 */
 	public function has($key);
 
 	/**
 	 * @param string $key Gets data for specified key
-	 * @return string|null Returns null if the cache has expired or non-existing data
+	 * @return string|null Returns null if the cached item doesn't exist or has expired
 	 */
 	public function get($key);
 
 	/**
 	 * @param string $key
 	 * @param $data
-	 * @param int $ttl Time for the data to live inside the cache
+	 * @param int $ttl Time in seconds before the data becomes expired
 	 * @return mixed
 	 */
 	public function put($key, $data, $ttl = 0);

--- a/FileSystemCache.php
+++ b/FileSystemCache.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Chad
+ * Date: 1/21/2015
+ * Time: 4:48 AM
+ */
+
+class FileSystemCache implements CacheInterface {
+
+	/**
+	 * @param string $key Check if the cache contains data for the specified key
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		$entry = $this->load($key);
+
+		return $this->expired($entry);
+	}
+
+	/**
+	 * @param string $key Gets data for specified key
+	 * @return string|null
+	 */
+	public function get($key)
+	{
+		$entry = $this->load($key);
+
+		if ($this->expired($entry))
+			$data = null;
+
+		return $entry->data;
+	}
+
+	/**
+	 * @param string $key
+	 * @param $data
+	 * @param int $ttl Time for the data to live inside the cache
+	 * @return mixed
+	 */
+	public function put($key, $data, $ttl = 0)
+	{
+		$this->store($key, $data, $ttl, time());
+	}
+
+	private function load($key)
+	{
+		return json_decode(file_get_contents($this->hash($key)));
+	}
+
+	private function store($key, $data, $ttl, $createdAt)
+	{
+		$entry = [
+			'createdAt' => $createdAt,
+			'ttl' => $ttl,
+			'data' => $data
+		];
+
+		file_put_contents($this->hash($key), json_encode($entry));
+	}
+
+	private function expired($entry)
+	{
+		return (time() + $entry->ttl) > $entry->createdAt;
+	}
+
+	private function hash($key)
+	{
+		return md5($key);
+	}
+
+}

--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -261,21 +261,19 @@ class riotapi {
 	}
 
 	private function request($call, $otherQueries=false, $static = false) {
-
-		//probably should put rate limiting stuff here
-		// Check rate-limiting queues if this is not a static call.
-		if (!$static) {
-			$this->updateLimitQueue($this->longLimitQueue, self::LONG_LIMIT_INTERVAL, self::RATE_LIMIT_LONG);
-			$this->updateLimitQueue($this->shortLimitQueue, self::SHORT_LIMIT_INTERVAL, self::RATE_LIMIT_SHORT);
-		}
-
-		//format the full URL
+				//format the full URL
 		$url = $this->format_url($call, $otherQueries);
 
 		//caching
 		if($this->cache !== null && $this->cache->has($url)){
 			$result = $this->cache->get($url);
 		} else {
+			// Check rate-limiting queues if this is not a static call.
+			if (!$static) {
+				$this->updateLimitQueue($this->longLimitQueue, self::LONG_LIMIT_INTERVAL, self::RATE_LIMIT_LONG);
+				$this->updateLimitQueue($this->shortLimitQueue, self::SHORT_LIMIT_INTERVAL, self::RATE_LIMIT_SHORT);
+			}
+
 			//call the API and return the result
 			$ch = curl_init($url);
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);

--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -42,7 +42,7 @@ class riotapi {
 	const API_URL_2_5 = "http://{region}.api.pvp.net/api/lol/{region}/v2.5/";
 	const API_URL_STATIC_1_2 = 'http://global.api.pvp.net/api/lol/static-data/{region}/v1.2/';
 
-	const API_KEY = 'INSERT_API_KEY_HERE';
+	const API_KEY = '587ff8f9-73bd-4174-8421-c4f6bcb986f1';
 
 	// Rate limit for 10 minutes
 	const LONG_LIMIT_INTERVAL = 600;
@@ -297,10 +297,7 @@ class riotapi {
 	//creates a full URL you can query on the API
 	private function format_url($call, $otherQueries=false){
 		//because sometimes your url looks like .../something/foo?query=blahblah&api_key=dfsdfaefe
-		if ($otherQueries) {
-			return str_replace('{region}', $this->REGION, $call) . '&api_key=' . self::API_KEY;
-		}
-		return str_replace('{region}', $this->REGION, $call) . '?api_key=' . self::API_KEY;
+		return str_replace('{region}', $this->REGION, $call) . ($otherQueries ? '&' : '?') . 'api_key=' . self::API_KEY;
 	}
 
 	public function getLastResponseCode(){

--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -42,7 +42,7 @@ class riotapi {
 	const API_URL_2_5 = "http://{region}.api.pvp.net/api/lol/{region}/v2.5/";
 	const API_URL_STATIC_1_2 = 'http://global.api.pvp.net/api/lol/static-data/{region}/v1.2/';
 
-	const API_KEY = '587ff8f9-73bd-4174-8421-c4f6bcb986f1';
+	const API_KEY = 'YOUR_API_KEY';
 
 	// Rate limit for 10 minutes
 	const LONG_LIMIT_INTERVAL = 600;

--- a/testing.php
+++ b/testing.php
@@ -1,10 +1,12 @@
 <?php
 include('php-riot-api.php');
+include('FileSystemCache.php');
+
 //testing classes
 $summoner_name = 'RiotSchmick';
 $summoner_id = 585897;
 
-$test = new riotapi('na');
+$test = new riotapi('na', new FileSystemCache('cache/'));
 //$r = $test->getSummonerByName($summoner_name);
 //$r = $test->getSummoner($summoner_id);
 //$r = $test->getSummoner($summoner_id,'masteries');


### PR DESCRIPTION
Split caching into it's own class. This way, you can use a different method of caching if you so desire (mysql, memcache, etc).

Also, this includes a fix to the rate limiting as proposed in https://github.com/kevinohashi/php-riot-api/pull/25. The rate limit will be ignored when hitting the cache.

If you have any comments, let me know!