### PR TITLE
Rate limiting

### DIFF
--- a/CacheInterface.php
+++ b/CacheInterface.php
@@ -18,8 +18,15 @@ interface CacheInterface {
 	 * @param string $key
 	 * @param $data
 	 * @param int $ttl Time in seconds before the data becomes expired
-	 * @return mixed
 	 */
 	public function put($key, $data, $ttl = 0);
+
+	/**
+	 * @param $key
+	 * @param $ttl
+	 * @param $callback
+	 * @return mixed
+	 */
+	public function remember($key, $ttl, $callback);
 
 }

--- a/NullCache.php
+++ b/NullCache.php
@@ -1,0 +1,38 @@
+<?php
+require_once('CacheInterface.php');
+
+class NullCache implements CacheInterface {
+
+    /**
+     * @param string $key Checks whether or not the cache contains unexpired data for the specified key
+     * @return bool
+     */
+    public function has($key)
+    {
+        return false;
+    }
+
+    /**
+     * @param string $key Gets data for specified key
+     * @return string|null Returns null if the cached item doesn't exist or has expired
+     */
+    public function get($key)
+    {
+        return null;
+    }
+
+    /**
+     * @param string $key
+     * @param $data
+     * @param int $ttl Time in seconds before the data becomes expired
+     * @return mixed
+     */
+    public function put($key, $data, $ttl = 0)
+    {
+    }
+
+    public function remember($key, $ttl, $callback)
+    {
+        return $callback();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Getting Started
  - DECODE_ENABLED is true by default. If you want your returns to be pure JSON and not an associative array, set it to false 
  - Take a look at testing.php for example code, including error handling, caching
 
+ - The default rate limiter will simply sleep until we're allowed to make a request to riot's API. If you want to override this, you can use your own custom
+   handler by passing it into `riotapi`'s constructor.
+
 Functions
 ------------
 

--- a/RateLimitHandler.php
+++ b/RateLimitHandler.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Chad
+ * Date: 6/24/2015
+ * Time: 8:37 PM
+ */
+
+interface RateLimitHandler {
+
+    /**
+     * @param int $retryAfter Retry-After header returned by the api
+     */
+    public function handleLimit($retryAfter);
+
+    /**
+     * @return bool returns whether or not to retry the api call after being handled
+     */
+    public function retryEnabled();
+
+}

--- a/RateLimitSleeper.php
+++ b/RateLimitSleeper.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Chad
+ * Date: 6/24/2015
+ * Time: 8:41 PM
+ */
+
+require_once('RateLimitHandler.php');
+
+class RateLimitSleeper implements RateLimitHandler {
+
+    private $debug = false;
+
+    public function enableDebugging()
+    {
+        $this->debug = true;
+    }
+
+    /**
+     * @param int $retryAfter Retry-After header returned by the api
+     */
+    public function handleLimit($retryAfter)
+    {
+        if ($this->debug) {
+            var_dump('sleeping for: ' . $retryAfter . "\n");
+        }
+
+        sleep($retryAfter);
+    }
+
+    /**
+     * @return bool returns whether or not to retry the api call after being handled
+     */
+    public function retryEnabled()
+    {
+        return true;
+    }
+
+}

--- a/RateLimitSleeper.php
+++ b/RateLimitSleeper.php
@@ -26,6 +26,11 @@ class RateLimitSleeper implements RateLimitHandler {
             var_dump('sleeping for: ' . $retryAfter . "\n");
         }
 
+
+        /**
+         * So this is our most basic handler for rate limiting... if we hit the cap, we'll simply sleep for
+         * the recommended duration before continuting
+         */
         sleep($retryAfter);
     }
 

--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -29,6 +29,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
+require_once('CacheInterface.php');
+require_once('NullCache.php');
+require_once('RateLimitHandler.php');
+require_once('RateLimitSleeper.php');
 
 class riotapi {
 	const API_URL_1_1 = 'https://{region}.api.pvp.net/api/lol/{region}/v1.1/';
@@ -43,8 +47,10 @@ class riotapi {
 	const API_URL_STATIC_1_2 = 'https://global.api.pvp.net/api/lol/static-data/{region}/v1.2/';
 	const API_URL_CURRENT_GAME_1_0 = 'https://{region}.api.pvp.net/observer-mode/rest/consumer/getSpectatorGameInfo/';
 
+	const HTTP_OK = 200;
+	const HTTP_RATE_LIMIT = 429;
 
-	const API_KEY = 'INSERT_API_KEY_HERE';
+	const API_KEY = '81be16eb-14f7-413c-a35b-99ec20ce5b20';
 
 	// Rate limit for 10 minutes
 	const LONG_LIMIT_INTERVAL = 600;
@@ -56,11 +62,15 @@ class riotapi {
 
 	// Cache variables
 	const CACHE_LIFETIME_MINUTES = 60;
+
 	private $cache;
+	private $rateLimitHandler;
 
 	private $REGION;	
 	//variable to retrieve last response code
-	private $responseCode; 
+	private $responseCode;
+	private $responseHeaders;
+	private $responseBody;
 
 
 	private static $errorCodes = array(0   => 'NO_RESPONSE',
@@ -72,21 +82,18 @@ class riotapi {
 									   503 => 'UNAVAILABLE');
 
 
-
-
 	// Whether or not you want returned queries to be JSON or decoded JSON.
 	// honestly I think this should be a public variable initalized in the constructor, but the style before me seems definitely to use const's.
 	// Remove this commit if you want. - Ahubers
 	const DECODE_ENABLED = TRUE;
 
-	public function __construct($region, CacheInterface $cache = null)
+	public function __construct($region, CacheInterface $cache = null, RateLimitHandler $rateLimitHandler = null)
 	{
 		$this->REGION = $region;
 
-		$this->shortLimitQueue = new SplQueue();
-		$this->longLimitQueue = new SplQueue();
-
-		$this->cache = $cache;
+		// if a cache and rate limiter weren't provided, then we'll just use these default ones
+		$this->cache = $cache = $cache !== null ? $cache : new NullCache();
+		$this->rateLimitHandler = $rateLimitHandler !== null ? $rateLimitHandler : new RateLimitSleeper();
 	}
 
 	//Returns all champion information.
@@ -246,85 +253,63 @@ class riotapi {
 		return $this->request($call);
 	}
 
-	private function updateLimitQueue($queue, $interval, $call_limit){
-		
-		while(!$queue->isEmpty()){
-			
-			/* Three possibilities here.
-			1: There are timestamps outside the window of the interval,
-			which means that the requests associated with them were long
-			enough ago that they can be removed from the queue.
-			2: There have been more calls within the previous interval
-			of time than are allowed by the rate limit, in which case
-			the program blocks to ensure the rate limit isn't broken.
-			3: There are openings in window, more requests are allowed,
-			and the program continues.*/
+	public function getLastResponseHeaders(){
+		return $this->responseHeaders;
+	}
 
-			$timeSinceOldest = time() - $queue->bottom();
-			// I recently learned that the "bottom" of the
-			// queue is the beginning of the queue. Go figure.
+	public function getLastResponseBody(){
+		return $this->responseBody;
+	}
 
-			// Remove timestamps from the queue if they're older than
-			// the length of the interval
-			if($timeSinceOldest > $interval){
-					$queue->dequeue();
-			}
-			
-			// Check to see whether the rate limit would be broken; if so,
-			// block for the appropriate amount of time
-			elseif($queue->count() >= $call_limit){
-				if($timeSinceOldest < $interval){ //order of ops matters
-					echo("sleeping for".($interval - $timeSinceOldest + 1)." seconds\n");
-					sleep($interval - $timeSinceOldest);
-				}
-			}
-			// Otherwise, pass through and let the program continue.
-			else {
-				break;
-			}
-		}
-
-		// Add current timestamp to back of queue; this represents
-		// the current request.
-		$queue->enqueue(time());
+	public function getLastResponseCode(){
+		return $this->responseCode;
 	}
 
 	private function request($call, $otherQueries=false, $static = false) {
 				//format the full URL
 		$url = $this->format_url($call, $otherQueries);
 
-		//caching
-		if($this->cache !== null && $this->cache->has($url)){
-			$result = $this->cache->get($url);
-		} else {
-			// Check rate-limiting queues if this is not a static call.
-			if (!$static) {
-				$this->updateLimitQueue($this->longLimitQueue, self::LONG_LIMIT_INTERVAL, self::RATE_LIMIT_LONG);
-				$this->updateLimitQueue($this->shortLimitQueue, self::SHORT_LIMIT_INTERVAL, self::RATE_LIMIT_SHORT);
+		$result = $this->cache->remember($url, self::CACHE_LIFETIME_MINUTES * 60, function () use ($url, $call, $otherQueries, $static)
+		{
+			$this->curlExecute($url);
+
+			if ($this->responseCode == self::HTTP_RATE_LIMIT) {
+				$retryAfter = (int) $this->responseHeaders['Retry-After'];
+				$this->rateLimitHandler->handleLimit($retryAfter);
+
+				if ($this->rateLimitHandler->retryEnabled()) {
+					return $this->request($call, $otherQueries, $static);
+				}
 			}
 
-			//call the API and return the result
-			$ch = curl_init($url);
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);			
-			$result = curl_exec($ch);
-			$this->responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-			curl_close($ch);
-
-
-			if($this->responseCode == 200) {
-				if($this->cache !== null){
-					$this->cache->put($url, $result, self::CACHE_LIFETIME_MINUTES * 60);
-				}
-	        	if (self::DECODE_ENABLED) {
-		            $result = json_decode($result, true);
-	        	}
-			} else {
+			if ($this->responseCode != self::HTTP_OK) {
 				throw new Exception(self::$errorCodes[$this->responseCode]);
 			}
-		}
+
+			$result = $this->responseBody;
+			if (self::DECODE_ENABLED) {
+				$result = json_decode($result, true);
+			}
+
+			return $result;
+		});
+
 		return $result;
+	}
+
+	private function curlExecute($url){
+		//call the API and return the result
+		$ch = curl_init($url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+		curl_setopt($ch, CURLOPT_HEADER, 1);
+		$result = curl_exec($ch);
+		list($header, $body) = explode("\r\n\r\n", $result, 2);
+		$this->responseHeaders = $this->parseHeaders($header);
+		$this->responseBody = $body;
+		$this->responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+		curl_close($ch);
 	}
 
 	//creates a full URL you can query on the API
@@ -333,8 +318,14 @@ class riotapi {
 		return str_replace('{region}', $this->REGION, $call) . ($otherQueries ? '&' : '?') . 'api_key=' . self::API_KEY;
 	}
 
-	public function getLastResponseCode(){
-		return $this->responseCode;
+	private function parseHeaders($header) {
+		$headers = array();
+		$headerLines = explode("\r\n", $header);
+		foreach ($headerLines as $headerLine) {
+			@list($key, $val) = explode(': ', $headerLine, 2);
+			$headers[$key] = $val;
+		}
+		return $headers;
 	}
 
 	public function debug($message) {

--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -50,7 +50,7 @@ class riotapi {
 	const HTTP_OK = 200;
 	const HTTP_RATE_LIMIT = 429;
 
-	const API_KEY = '81be16eb-14f7-413c-a35b-99ec20ce5b20';
+	const API_KEY = 'INSERT_API_KEY_HERE';
 
 	// Rate limit for 10 minutes
 	const LONG_LIMIT_INTERVAL = 600;
@@ -273,6 +273,10 @@ class riotapi {
 		{
 			$this->curlExecute($url);
 
+			/**
+			 * Here we are going to check if we were rate limited. If we WERE rate limited, then lets call our rate limit
+			 * handler and let that class deal with it.
+			 */
 			if ($this->responseCode == self::HTTP_RATE_LIMIT) {
 				$retryAfter = (int) $this->responseHeaders['Retry-After'];
 				$this->rateLimitHandler->handleLimit($retryAfter);


### PR DESCRIPTION
This pull request implements "proper" rate limiting. Essentially, you can pass in a `RateLimitHandler` class, which lets you handle being rate limited in whatever way you want (maybe log to a database and die, whatever). The default handler will simply sleep for the duration specified by the `Retry-After` header, which is provided by riot when you have exceeded your limit.
