### PR TITLE
Riot API V3 + multicurl management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Getting Started
 
  - Replace INSERT_API_KEY_HERE
  - Create folder called 'cache' wherever the script is (make sure it's writeable by php-riot-api)
- - Create an instance of riotapi - $instance = new riotapi($region); 
- - $region can be na, euw, eune, br, tr (br/tr only can call getLeague() and getTeam() functions)
+ - Create an instance of riotapi - $instance = new riotapi($platform); 
+ - $platform can be na1, euw1, eune1, br1, ru, kr, oc1, la1, la2, jp1, pbe1, tr1 (br/tr only can call getLeague() and getTeam() functions)
  - Make Calls to the functions listed below and receive JSON data
- - Caching is done locally, instantiate php-riot-api with "new riotapi('na', new FileSystemCache('cache/'));" to create a cache in the subfolder 'cache'
+ - Caching is done locally, instantiate php-riot-api with "new riotapi('na1', new FileSystemCache('cache/'));" to create a cache in the subfolder 'cache'
  - DECODE_ENABLED is true by default. If you want your returns to be pure JSON and not an associative array, set it to false 
  - Take a look at testing.php for example code, including error handling, caching
 
@@ -26,54 +26,58 @@ Functions
 	//Returns all champion information.
 	getChampion();
 
-	//Change region
+	//Change platform
 	setRegion($region);
 
 	// Returns all free champions.
+	getChampion(true);
 	getFreeChampions();
 
 	//performs a static call. Not counted in rate limit.
-	getStatic($call, $id);
+	getStatic($call, $id = null, $params = null);
 
-	//New Riot API call. Returns match details given a match id.
-	getMatch($matchId);
 	//Returns match details including timeline (if exists) given a match id.
-	getMatch($matchId, true);
+	//Use with care, rate limiting is not ready for this function
+	getMatch($matchId);
+	//Returns match details given a match id, without timeline.
+	getMatch($matchId, false);
 
-	//Returns a user's matchHistory given their summoner id.
-	getMatchHistory($summoner_id);
+	//Returns timeline of a match
+	getTimeline($matchId)
 
-	//Returns game statistics given a summoner's id.
-	getGame($summoner_id);
+	//Returns a user's matchList given their account id.
+	public function getMatchList($accountId,$params=null)
 
 	//Returns the league of a given summoner.
 	getLeague($summoner_id);
-	getLeague($summoner_id, "entry");
-
-	//Returns league information given a *list* of teams.
-	getLeagueByTeam($team_ids);
+	getLeaguePosition($summoner_id);
 
 	//Returns the challenger ladder.
-	getChallenger();
-
-	//Returns a summoner's stats given summoner id.
-	getStats($summoner_id);
-	getStats($summoner_id,'ranked');
+	getChallenger($queue = "RANKED_SOLO_5x5");
+	//Returns the master ladder.
+	getMaster($queue = "RANKED_SOLO_5x5");
 
 	//returns a summoner's id
 	getSummonerId($summoner_name);
+	//returns an account's id
+	getSummonerAccountId($summoner_name);
 
 	//Returns summoner info given summoner id.
 	getSummoner($summoner_id);
-	getSummoner($summoner_id,'masteries');
-	getSummoner($summoner_id,'runes');
-	getSummoner($summoner_id,'name');
+	//Returns summoner masteries given summoner id.
+	getMasteries($summoner_id);
+	//Returns summoner runes given summoner id.
+	getRunes($summoner_id);
+
+	//Returns summoner info given account id.
+	getSummoner($accountId);
 
 	//Gets a summoner's info given their name, instead of id.
 	getSummonerByName($summoner_name);
-
-	//Gets the teams of a summoner, given summoner id.
-	getTeam($summoner_id);
+	
+	//Return details of an array of matches
+	//Use with care, rate limiting is not ready for this function
+	getMatches($ids, $includeTimeline = true)
 
 Not Complete
 ------------

--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -101,7 +101,7 @@ class riotapi {
 	}
 
 	//Returns all free champion information.
-	public function getFreeChampion(){
+	public function getFreeChampions(){
 		$call = 'champions?freeToPlay=true';
 
 		//add API URL to the call

--- a/testing.php
+++ b/testing.php
@@ -4,25 +4,34 @@ include('FileSystemCache.php');
 
 //testing classes
 //using double quotes seems to make all names work (see issue: https://github.com/kevinohashi/php-riot-api/issues/33)
-$summoner_name = "RiotSchmick"; 
-$summoner_id = 585897;
+$api = new riotapi('euw1', new FileSystemCache('cache/'));
 
-$test = new riotapi('na');
+$id=23516141;
+
+// $r = $api->getChampion();
+// $r = $api->getChampion(true);
+// $r = $api->getChampionMastery(23516141);
+// $r = $api->getChampionMastery(23516141,1);
+// $r = $api->getCurrentGame(23516141);
+// $api->setPlatform("na1");
+// $r = $api->getStatic("champions", 1, "locale=fr_FR&tags=image&tags=spells");
+// $api->setPlatform("euw1");
+// $r = $api->getMatch(2898677684);
+// $r = $api->getMatch(2898677684,false);
+// $r = $api->getTimeline(2898677684);
+// $r = $api->getMatchList(27695644);
+// $params = array(
+	// "queue"=>array(4,8),
+	// "beginTime"=>1439294958000
+// );
+// $r = $api->getMatchList(27695644, $params);
+// $r = $api->getRecentMatchList(27695644);
+// $r = $api->getLeague(24120767);
+// $r = $api->getLeaguePosition(24120767);
+// $r = $api->getChallenger();
+// $r = $api->getMaster();
 
 
-$testCache = new riotapi('na', new FileSystemCache('cache/'));
-//$r = $test->getSummonerByName($summoner_name);
-
-//$r = $test->getSummoner($summoner_id);
-//$r = $test->getSummoner($summoner_id,'masteries');
-//$r = $test->getSummoner($summoner_id,'runes');
-//$r = $test->getSummoner($summoner_id,'name');
-//$r = $test->getStats($summoner_id);
-//$r = $test->getStats($summoner_id,'ranked');
-//$r = $test->getTeam($summoner_id);
-//$r = $test->getLeague($summoner_id);
-//$r = $test->getGame($summoner_id);
-//$r = $test->getChampion();
 try {
     $r = $test->getSummonerByName($summoner_name);
     print_r($r);


### PR DESCRIPTION
I updated for the Riot API V3.
I deleted all soon to be deprecated function and added the new ones.

I added a multi curl function to handle multiple requested at the same time. I use it for example in the getMatch function, as the timeline can only be obtained by a separated call now, so if timeline is needed, both calls (match and timeline) are done at the same time. Usefull too when calling a bunch of matches.

Now that the API supports it, I moved the api key to the header, as it is easier to use with multiple arguments queries, also for cache, you can get a shared cache with other applications with different keys without redundant call only because of different key in url.