### PR TITLE
Updated getMatch and getMatches to pass an accountId in the query

### DIFF
--- a/php-riot-api.php
+++ b/php-riot-api.php
@@ -147,8 +147,12 @@ class riotapi {
 	//New to my knowledge. Returns match details.
 	//Now that timeline is a separated call, when includedTimeline is true, two calls are done at the same time.
 	//Data is then processed to match the old structure, with timeline data included in the match data
-	public function getMatch($matchId, $includeTimeline = true) {
+	//UPDATE : you can now pass an accountId to know which participant is the player, even in normale game
+	public function getMatch($matchId, $accountId = false, $includeTimeline = true) {
 		$call = self::API_URL_MATCH_3  . 'matches/' . $matchId;
+
+		if($accountId)
+			$call .= "?forAccountId=" . $accountId;
 		
 		if(!$includeTimeline)
 			return $this->request($call);
@@ -314,12 +318,17 @@ class riotapi {
 	}
 
 	//Gets data of matches, given array of id.
-	public function getMatches($ids, $includeTimeline = true){
+	//UPDATE : you can now pass an accountId to know which participant is the player, even in normale game
+	public function getMatches($ids, $accountId = false, $includeTimeline = true){
 		
 		$calls=array();
 		
 		foreach($ids as $matchId){
 			$call = self::API_URL_MATCH_3  . 'matches/' . $matchId;
+
+			if($accountId)
+				$call .= "?forAccountId=" . $accountId;
+			
 			$calls["match-".$matchId] = $call;
 			
 			if($includeTimeline)

--- a/testing.php
+++ b/testing.php
@@ -16,8 +16,9 @@ $id=23516141;
 // $api->setPlatform("na1");
 // $r = $api->getStatic("champions", 1, "locale=fr_FR&tags=image&tags=spells");
 // $api->setPlatform("euw1");
-// $r = $api->getMatch(2898677684);
-// $r = $api->getMatch(2898677684,false);
+// $r = $api->getMatch(3256751043);
+// $r = $api->getMatch(3256751043,27695644);
+// $r = $api->getMatch(3256751043,false,false);
 // $r = $api->getTimeline(2898677684);
 // $r = $api->getMatchList(27695644);
 // $params = array(


### PR DESCRIPTION
With deprecation of game API, you can't tell from the matchlist who was a player in a match in normal game in case of two same champions in the game. The match API just released an update allowing to pass an accountId in the match request to get the participantId of a targeted player.